### PR TITLE
Fix for no vote rewards

### DIFF
--- a/src/main/java/com/spinalcraft/spinalvote/Spinalvote.java
+++ b/src/main/java/com/spinalcraft/spinalvote/Spinalvote.java
@@ -11,7 +11,7 @@ import com.spinalcraft.skull.SpinalcraftPlugin;
 
 public class Spinalvote extends SpinalcraftPlugin{
 	
-	public static final int NUM_WEBSITES = 2;
+	public static final int NUM_WEBSITES = 1;
 	public ConsoleCommandSender console;
 	private SpinalvoteListener voteListener;
 	private CommandExecutor executor;


### PR DESCRIPTION
Planetminecraft doesn't send the vote event to the servers anymore, so only 1 site is required to get the reward.